### PR TITLE
Initial change to get Marlin4due usable with the RAMPS-FD v1 card:

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -495,7 +495,9 @@
    * Helper Macros for heaters and extruder fan
    */
   
-  #ifdef INVERTED_HEATER_PINS
+  // #ifdef INVERTED_HEATER_PINS 
+  // Dawson - rename to something that is more correctly descriptive . . . More than just heaters on the MOSFETS . . . 
+  #ifdef INVERTED_MOSFET_CHANNELS
     #define WRITE_HEATER(pin,value) WRITE(pin,!value)
   #else
     #define WRITE_HEATER(pin,value) WRITE(pin,value)
@@ -520,7 +522,12 @@
     #define WRITE_HEATER_BED(v) WRITE_HEATER(HEATER_BED_PIN, v)
   #endif
   #if HAS_FAN
-    #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+    //#ifdef INVERTED_HEATER_PINS //Dawson - layer fan control for RAMPS-FDv1
+    #ifdef INVERTED_MOSFET_CHANNELS //Dawson - layer fan control for RAMPS-FDv1
+      #define WRITE_FAN(v) WRITE(FAN_PIN, !v)
+    #else
+      #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+    #endif // INVERTED_HEATER_PINS
   #endif
 
   #define HAS_BUZZER ((defined(BEEPER) && BEEPER >= 0) || defined(LCD_USE_I2C_BUZZER))

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -251,7 +251,7 @@
 #define DEFAULT_MINSEGMENTTIME        20000
 
 // If defined the movements slow down when the look ahead buffer is only half full
-#define SLOWDOWN
+//#define SLOWDOWN
 
 // Frequency limit
 // See nophead's blog for more info
@@ -395,7 +395,7 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //#define HEATERS_PARALLEL
 
 // for smoother temperature
-#define MEDIAN_COUNT 3
+#define MEDIAN_COUNT 10
 
 //===========================================================================
 //================================= Buffers =================================
@@ -406,16 +406,16 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 // The number of linear motions that can be in the plan at any give time.
 // THE BLOCK_BUFFER_SIZE NEEDS TO BE A POWER OF 2, i.g. 8,16,32 because shifts and ors are used to do the ring-buffering.
 #ifdef SDSUPPORT
-  #define BLOCK_BUFFER_SIZE 32   // SD,LCD,Buttons take more memory, block buffer needs to be smaller
+  #define BLOCK_BUFFER_SIZE 16   // SD,LCD,Buttons take more memory, block buffer needs to be smaller
 #else
-  #define BLOCK_BUFFER_SIZE 32 // maximize block buffer
+  #define BLOCK_BUFFER_SIZE 16 // maximize block buffer
 #endif
 
 // @section more
 
 //The ASCII buffer for receiving from the serial:
 #define MAX_CMD_SIZE 96
-#define BUFSIZE 8
+#define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6272,7 +6272,16 @@ void plan_arc(
       ) {
         lastMotor = ms; //... set time to NOW so the fan will turn on
       }
+      
+  // Dawson - try to get the motor/controller card fan control working with RAMPS-FD v1
+  // #ifdef INVERTED_HEATER_PINS
+  #ifdef INVERTED_MOSFET_CHANNELS
+      uint8_t speed = (lastMotor == 0 || ms >= lastMotor + (CONTROLLERFAN_SECS * 1000UL)) ? 255 : (255 - CONTROLLERFAN_SPEED);
+  #else
       uint8_t speed = (lastMotor == 0 || ms >= lastMotor + (CONTROLLERFAN_SECS * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
+      CUMBUCKET ERROR
+  #endif
+ 
       // allows digital or PWM fan output to be used (see M42 handling)
       digitalWrite(CONTROLLERFAN_PIN, speed);
       analogWrite(CONTROLLERFAN_PIN, speed);

--- a/Marlin/pins_RAMPS_FD.h
+++ b/Marlin/pins_RAMPS_FD.h
@@ -7,8 +7,9 @@
 //
 #ifdef MB(RAMPS_FD_V1)
   #define INVERTED_HEATER_PINS
+  #define INVERTED_MOSFET_CHANNELS
    //WARNING:If you have a RAMPS_FD_V1 modded for bugfix (same http://forums.reprap.org/read.php?219,424146,507810), you must use RAMPS_FD_V2 configuration 
-  // No EEPROM
+  // No EEPROM - unless you trivially add it . . .
   // Use 4k7 thermistor tables
 #else
   // #define RAMPS_FD_V2
@@ -56,19 +57,20 @@
 
 #define PS_ON_PIN          -1
 
-#define KILL_PIN           -1
+#define KILL_PIN           41 //Dawson
 
 
-#define HEATER_BED_PIN     9    // BED
+#define HEATER_BED_PIN     8    // BED //Dawson - OTW, not on the right power feed!
 
-#define HEATER_0_PIN       8
+#define HEATER_0_PIN       9 //Dawson - OTW, not on the right power feed!
 #define HEATER_1_PIN       -1
-#define HEATER_2_PIN       11
+// #define HEATER_2_PIN       11
+#define HEATER_2_PIN       -1 // Dawson - use this for stepper fan control
 
 #define TEMP_BED_PIN       0   // ANALOG NUMBERING
 
 #define TEMP_0_PIN         1   // ANALOG NUMBERING
-#define TEMP_1_PIN         -1  // 2    // ANALOG NUMBERING
+#define TEMP_1_PIN         2  // 2    // ANALOG NUMBERING
 #define TEMP_2_PIN         -1  // 3     // ANALOG NUMBERING
 
 #define TEMP_3_PIN         -1   // ANALOG NUMBERING
@@ -77,7 +79,7 @@
 
 
   #ifdef NUM_SERVOS
-    #define SERVO0_PIN         11
+    #define SERVO0_PIN         7
 
     #if NUM_SERVOS > 1
       #define SERVO1_PIN         6


### PR DESCRIPTION
Fully implement inverted mosfet control to include fans, not just heaters.

Correct errant LCD definition to one from U8Glib to get RepRap Graphic Discount Controller
to work with Arduino Due

Correct pins_RAMPS_FD.h to actually represent the hardware - mis-assignments present.

Rename INVERTED_HEATER_PINS to INVERTED_MOSFET_CHANNELS to more accurately represent the actual situation.
