### PR TITLE
MAX6675 implementation for the extrusion 1 and 2 (only RADDS)

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -360,7 +360,9 @@
     #define HEATER_0_USES_THERMISTOR
   #endif
 
-  #if TEMP_SENSOR_1 == -1
+  #if TEMP_SENSOR_1 == -2
+    #define HEATER_1_USES_MAX6675
+  #elif TEMP_SENSOR_1 == -1
     #define HEATER_1_USES_AD595
   #elif TEMP_SENSOR_1 == 0
     #undef HEATER_1_MINTEMP

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -109,7 +109,7 @@ Here are some standard links for getting your machine calibrated:
 //--NORMAL IS 4.7kohm PULLUP!-- 1kohm pullup can be used on hotend sensor, using correct resistor and table
 //
 //// Temperature sensor settings:
-// -2 is thermocouple with MAX6675 (only for sensor 0)
+// -2 is thermocouple with MAX6675 (only for sensor 0 or sensor 1)
 // -1 is thermocouple with AD595
 // 0 is not used
 // 1 is 100k thermistor - best choice for EPCOS 100k (4.7k pullup)

--- a/Marlin/pins_RADDS.h
+++ b/Marlin/pins_RADDS.h
@@ -160,12 +160,13 @@
 
 // SPI for Max6675 Thermocouple
 
-//works with radds??? #ifndef SDSUPPORT
-//// these pins are defined in the SD library if building with SD support
-//  #define MAX_SCK_PIN          52
-//  #define MAX_MISO_PIN         50
-//  #define MAX_MOSI_PIN         51
-//  #define MAX6675_SS       53
-//#else
-//  #define MAX6675_SS       49
-//#endif
+//Extruder 1
+  #define MAX_SCLK_PIN 27
+  #define MAX_CS_PIN   29
+  #define MAX_MISO_PIN 31
+  
+//Extruder 2
+  #define MAX_SCLK1_PIN 33
+  #define MAX_CS1_PIN   35
+  #define MAX_MISO1_PIN 37
+


### PR DESCRIPTION
I needed to use two thermocouples for my extruders (since temperatures exceed 450 ° C), I revised the code to implement them.

Functions:
`float readCelsius (int *); 
spiread bytes (int *);`
They are copied (with some minor modifications) from lebreria offcial MAX6675 Arduino.

I hope I was helpful and if there are improvements that can be done, do not hesitate to comment :)
